### PR TITLE
Fix for placeholders minimizing to trim

### DIFF
--- a/modules/ui/org.eclipse.fx.ui.workbench.renderers.fx/src/main/java/org/eclipse/fx/ui/workbench/renderers/fx/addons/internal/DefaultTrimStackImpl.java
+++ b/modules/ui/org.eclipse.fx.ui.workbench.renderers.fx/src/main/java/org/eclipse/fx/ui/workbench/renderers/fx/addons/internal/DefaultTrimStackImpl.java
@@ -400,7 +400,12 @@ public class DefaultTrimStackImpl implements TrimStack {
 						continue;
 					}
 					
-					this.trimStackTB.getChildren().add(createButton((MUILabel) stackElement));
+					if (stackElement instanceof MPlaceholder) {
+						this.trimStackTB.getChildren().add(createButton((MUILabel) stackElement.getRef()));
+					}
+					else {
+						this.trimStackTB.getChildren().add(createButton((MUILabel) stackElement));
+					}
 				}
 			} else if (theStack.getTags().contains(IPresentationEngine.NO_AUTO_COLLAPSE)) {
 				// OK to be empty and still minimized


### PR DESCRIPTION
Problem: When the minmax addon (with partial restore) is used on a perspective that is composed of placeholders, the trim containing the buttons for the placeholders is not created (errors out). 

The proposed fix is for this problem. Noe that I'm not able to fully compile the project to test this out.